### PR TITLE
chore: Bump crystal 1.1.1 and fix compatibility, Bump shards

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -1,12 +1,12 @@
 version: 2.0
 shards:
   circuit_breaker:
-    git: https://github.com/tpei/circuit_breaker.git
-    version: 0.0.5+git.commit.ff3e5e6fca31969ff2f0e3661cef5b2118478c6d
+    git: https://github.com/noellabo/circuit_breaker.git
+    version: 0.0.5+git.commit.33e5951aaa69505e1eccea392543f1af5fcfd489
 
   dotenv:
     git: https://github.com/gdotdesign/cr-dotenv.git
-    version: 0.7.0
+    version: 1.0.0
 
   earl:
     git: https://github.com/ysbaddaden/earl.git
@@ -14,17 +14,17 @@ shards:
 
   openssl_ext:
     git: https://github.com/stakach/openssl_ext.git
-    version: 1.2.2
+    version: 2.1.5
 
   pool:
-    git: https://github.com/watzon/pool.git
-    version: 0.3.0
+    git: https://github.com/ysbaddaden/pool.git
+    version: 0.2.4
 
   redis:
-    git: https://github.com/noellabo/crystal-redis.git
-    version: 2.6.0+git.commit.564ec37a6ffdf29fefe8a7c26696765203138df3
+    git: https://github.com/stefanwille/crystal-redis.git
+    version: 2.8.2
 
   webmock:
     git: https://github.com/manastech/webmock.cr.git
-    version: 0.13.0
+    version: 0.14.0
 

--- a/shard.yml
+++ b/shard.yml
@@ -11,26 +11,26 @@ dependencies:
     branch: master
   openssl_ext:
     github: stakach/openssl_ext
-    version: '~> 1.2.2'
+    version: '~> 2.1.5'
   redis:
-    github: noellabo/crystal-redis
-    branch: master
+    github: stefanwille/crystal-redis
+    version: '~> 2.8.0'
   dotenv:
     github: gdotdesign/cr-dotenv
-    version: '~> 0.7.0'
+    version: '~> 1.0.0'
   circuit_breaker:
-    github: tpei/circuit_breaker
+    github: noellabo/circuit_breaker
     branch: master
 
 development_dependencies:
   webmock:
     github: manastech/webmock.cr
-    version: '~> 0.13.0'
+    version: '~> 0.14.0'
 
 targets:
   pub-relay:
     main: src/entrypoint.cr
 
-crystal: 0.35.1
+crystal: ">= 1.1.1, < 2.0"
 
 license: AGPL3

--- a/src/activity.cr
+++ b/src/activity.cr
@@ -30,7 +30,7 @@ class PubRelay::Activity
     d = @duplicate
     return d unless d.nil?
 
-    @duplicate = redis.zadd("activity_id", (@published || Time.utc).to_unix_f, @id, nx: true) == 0
+    @duplicate = redis.zadd("activity_id", (@published || Time.utc).to_unix_f.to_s, @id, nx: true) == 0
   end
 
   def follow?

--- a/src/web_server/http_signature.cr
+++ b/src/web_server/http_signature.cr
@@ -121,7 +121,7 @@ struct PubRelay::WebServer::HTTPSignature
       when "digest"
         body_digest = OpenSSL::Digest.new("SHA256")
         body_digest.update(body)
-        "digest: SHA-256=#{Base64.strict_encode(body_digest.digest)}"
+        "digest: SHA-256=#{Base64.strict_encode(body_digest.final)}"
       else
         request_header = request.headers[header_name]?
         unless request_header


### PR DESCRIPTION
## Crystal

Change from 0.35.1 to 1.1.1 or later.

## Shards

### circuit_breaker

Temporarily switch to a forked build to deal with changes since Crystal 0.34.0.
### crystal-redis

The zadd patch applied by the fork has been imported into the mainline by pull request. Bring it back to the mainline.

## Fix compatibility

- OpenSSL::Digest#digest to OpenSSL::Digest#final
- URI#full_path to URI#request_target
- Redis::PooledClient#zadd score needs to be "a string of floating point numbers", fixed.